### PR TITLE
Declare the project properties for build, install, and test with pyproject.toml.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 Russ Abbott, Jay Patel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ We examine the history of Artificial Intelligence, from its audacious beginnings
 We offer a tutorial on constraint programming solvers that should be accessible to most software developers. We show how constraint programming works, how to implement constraint programming in Python, and how to integrate a Python constraint-programming solver with other Python code. 
 
 
+To install from [PyPi](https://pypi.org/project/pylog/): `pip install pylog``
+
+If you are editing pylog source, running tests, or building installable packages for upload to [PyPi](https://pypi.org/project/pylog/), install as an editable install with test and buid prequisites:
+
+  `pip install -e .[test,build]` from the project root directory.  If you don't want to run tests or build an installable package, 
+  `pip install -e .`
+
+  To build the installable package for upload:
+  `py -m build` from the project root.
+
+  To run the tests, run them from the project root:
+  `pytest`
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+[tools.setuptools]
+packages=["pylog"]
+[tool.setuptools.packages.find]
+include=["pylog"]
+[project]
+name = "pylog"
+authors = [{name = "Russ Abbott", email = "Russ.Abbott@gmail.com"},
+            {name = "Jay Patel", email = "imjaypatel12@gmail.com"}]
+requires-python = ">=3.7"
+readme = "README.md"
+license = {file = "LICENSE"}
+classifiers = [
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.7',
+        'Topic :: Software Development :: Libraries :: Python Modules',]
+version="1.1"        
+description="Python implementation of Prolog features."
+keywords=["prolog,logic programming"]
+[project.urls]
+Home = "https://github.com/RussAbbott/pylog"
+
+[project.optional-dependencies]
+build= ["build"]
+test=["pytest >= 7.4.0"]
+
+# pyproject.toml
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = [
+    "tests",
+ ]

--- a/tests/test_module_exists.py
+++ b/tests/test_module_exists.py
@@ -1,0 +1,9 @@
+import pytest
+import importlib.util as u
+def test_pylog_exists():
+    spec=u.find_spec("pylog")
+    assert(spec)
+
+def test_pylog_loads():
+    import pylog 
+    assert(pylog)


### PR DESCRIPTION
editable installs (similar to https://github.com/RussAbbott/pylog/pull/1).  The advantage of doing it with pyroject.toml now is:
- pyproject.toml specifies the files included in the package build (for install to pypi).  Gets rid of setup.py.  This  is the way installers are going.  
- test locations are specified with pyrpoject.toml, useful for IDEs.
- if you bring over https://github.com/RussAbbott/pylog/pull/1 you can just delete setup.py, setup.cfg, and tweak pyproject.toml.  By going to the src structure in https://github.com/RussAbbott/pylog/pull/1 the pyroject.toml can be simplified  a bit, and the project built with a simpler tool (flit) rather than setuptools.  
- added a simple test that the pylog module exists and can be imported.



